### PR TITLE
Add missing `extern "C"`

### DIFF
--- a/include/dlfcn.h
+++ b/include/dlfcn.h
@@ -1,6 +1,10 @@
 #ifndef _DLFCN_H
 #define _DLFCN_H 1
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define RTLD_LAZY 0x00001
 #define RTLD_NOW 0x00002
 #define RTLD_GLOBAL 0x00100
@@ -13,5 +17,9 @@ extern int dlclose (void *__handle);
 extern void *dlsym (void *__handle, const char *__name);
 
 extern char *dlerror (void);
+  
+#ifdef __cplusplus
+}
+#endif
 
 #endif


### PR DESCRIPTION
Fixes usage with C++ projects