### PR TITLE
Fix resolving Variable Exports

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,7 @@ project(dl)
 
 add_library(${PROJECT_NAME} STATIC
   src/main.c
+  src/taiutils.c
 )
 
 install(TARGETS ${PROJECT_NAME}

--- a/src/main.c
+++ b/src/main.c
@@ -4,7 +4,7 @@
 #include <psp2common/types.h>
 #include <psp2/kernel/clib.h>
 #include <psp2/kernel/modulemgr.h>
-#include <taihen.h>
+#include "taiutils.h"
 
 typedef struct SceSblDmac5HashTransformParam {
    void* src;
@@ -84,7 +84,7 @@ void *dlsym(void *__handle, const char *__name)
 
     uintptr_t func;
 
-    ret = taiGetModuleExportFunc(info.module_name, TAI_ANY_LIBRARY, nid, &func);
+    ret = module_get_export(info.module_name, TAI_ANY_LIBRARY, nid, &func);
 
     if (ret == 0)
     {
@@ -101,13 +101,13 @@ void *dlsym(void *__handle, const char *__name)
         }
         nid = (dst[0] << 24) | (dst[1] << 16) | (dst[2] << 8) | dst[3];
 
-        ret = taiGetModuleExportFunc(info.module_name, TAI_ANY_LIBRARY, nid, &func);
+        ret = module_get_export(info.module_name, TAI_ANY_LIBRARY, nid, &func);
         if (ret == 0)
         {
             return (void*)func;
         }
     }
-    set_dl_error("[libdl] taiGetModuleExportFunc(%s, TAI_ANY_LIBRARY, 0x%08x, &func) error: 0x%08x\n", info.module_name, nid, ret);
+    set_dl_error("[libdl] module_get_export(%s, TAI_ANY_LIBRARY, 0x%08x, &func) error: 0x%08x\n", info.module_name, nid, ret);
     return NULL;
 }
 

--- a/src/taiutils.c
+++ b/src/taiutils.c
@@ -1,0 +1,50 @@
+#include "taiutils.h"
+
+typedef struct sce_module_exports {
+	uint16_t size;           // size of this structure; 0x20 for Vita 1.x
+	uint8_t  lib_version[2]; //
+	uint16_t attribute;      // ?
+	uint16_t num_functions;  // number of exported functions
+	uint16_t num_vars;       // number of exported variables
+	uint16_t unk;
+	uint32_t num_tls_vars;   // number of exported TLS variables?  <-- pretty sure wrong // yifanlu
+	uint32_t lib_nid;        // NID of this specific export list; one PRX can export several names
+	char     *lib_name;      // name of the export module
+	uint32_t *nid_table;     // array of 32-bit NIDs for the exports, first functions then vars
+	void     **entry_table;  // array of pointers to exported functions and then variables
+} sce_module_exports_t;
+
+int module_get_export(const char *module_name, int32_t library_nid, uint32_t func_nid, void *func_dst)
+{
+	tai_module_info_t tai_info;
+	tai_info.size = sizeof(tai_info);
+
+	if(taiGetModuleInfo(module_name, &tai_info) < 0){
+		return 1;
+	}
+
+	uint32_t i = tai_info.exports_start;
+
+	while (i < tai_info.exports_end) {
+
+        sce_module_exports_t *impInfo = (sce_module_exports_t *)(i);
+
+        uint32_t *func_nid_table = (uint32_t *)(impInfo->nid_table);
+        uint32_t *func_entry_table = (uint32_t *)(impInfo->entry_table);
+
+        for(int j = 0; j < impInfo->num_functions + impInfo->num_vars; j++) {
+
+            if(func_nid_table[j] == func_nid){
+
+            *(uintptr_t *)(func_dst) = (uintptr_t)func_entry_table[j];
+
+            return 0;
+
+            }
+        }
+
+	i += impInfo->size;
+	}
+
+	return 2;
+}

--- a/src/taiutils.h
+++ b/src/taiutils.h
@@ -1,0 +1,9 @@
+#ifndef TAIUTILS_H
+#define TAIUTILS_H
+
+#include <psp2/kernel/modulemgr.h>
+#include <taihen.h>
+
+int module_get_export(const char *module_name, int32_t library_nid, uint32_t func_nid, void *func_dst);
+
+#endif


### PR DESCRIPTION
Taihen doesn't do this by default, so I made a small helper functions to search the entire NID table instead of just the functions